### PR TITLE
fix: forgot to build the package

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -31,6 +31,9 @@ jobs:
         env:
           CI: "true"
 
+      - name: Build
+        run: pnpm build
+
       - name: Test
         run: pnpm test
 
@@ -68,4 +71,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           pnpm install --frozen-lockfile
+          pnpm build
           npx auto shipit


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>8.0.1--canary.541.156e09e.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install react-use-disclosure@8.0.1--canary.541.156e09e.0
  # or 
  yarn add react-use-disclosure@8.0.1--canary.541.156e09e.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
