### PR TITLE
fix: add exports field to package.json for ESM/CJS resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,20 @@
     "dist/"
   ],
   "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.cts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
   "scripts": {
     "dev": "tsdown index.ts --format esm,cjs --dts --watch",
     "build": "tsdown index.ts --format esm,cjs --dts --minify",


### PR DESCRIPTION
## Summary
- Adds an `exports` field to `package.json` with explicit `import`/`require` conditions and matching type declarations, fixing SSR `ERR_MODULE_NOT_FOUND` when the package is consumed under strict Node ESM resolution (Vite SSR / Nitro).
- Corrects the `module` and `types` fields to point at files that tsdown actually emits (`dist/index.mjs`, `dist/index.d.cts`).

Closes #584

## Test plan
- [x] `pnpm build` — dist contains `index.cjs`, `index.mjs`, `index.d.cts`, `index.d.mts`
- [x] `pnpm test` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)