### PR TITLE
ci: grant issues and pull-requests write to release workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,6 +5,8 @@ on: [push]
 permissions:
   id-token: write # Required for OIDC
   contents: write
+  issues: write
+  pull-requests: write
 
 jobs:
   tests:

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .npmrc
 dist/
 coverage/
+.context/


### PR DESCRIPTION
## Summary
- Adds `issues: write` and `pull-requests: write` to the Node CI workflow permissions so `auto shipit` can post its "released" comment on linked issues/PRs (fixes the `403 Resource not accessible by integration` seen on the v12.0.0 release).
- Gitignores the local `.context/` directory used by the Conductor workspace.

## Test plan
- [ ] Trigger the release workflow on master and confirm the released comment posts without a 403.

🤖 Generated with [Claude Code](https://claude.com/claude-code)